### PR TITLE
Some envs for `php` and `php-fpm` settings

### DIFF
--- a/7.4-fpm/envsubst.sh
+++ b/7.4-fpm/envsubst.sh
@@ -2,7 +2,18 @@
 
 set -e
 
-# 1. PHP-FPM default settings (www.conf)
+CWD=/var/data/php-fpm
+
+# 1. PHP-FPM default settings (php-fpm.conf)
+XERROR_LOG=/proc/self/fd/2
+XLOG_LEVEL=error
+
+if [[ -z "$PHP_FPM_ERROR_LOG" ]]; then export PHP_FPM_ERROR_LOG=$XERROR_LOG; fi
+if [[ -z "$PHP_FPM_LOG_LEVEL" ]]; then export PHP_FPM_LOG_LEVEL=$XLOG_LEVEL; fi
+
+envsubst < "$CWD/php-fpm.tmpl.conf" > "/usr/local/etc/php-fpm.conf"
+
+# 2. PHP-FPM WWW Pool (www.conf)
 XUSER=www-data
 XGROUP=www-data
 XLISTEN=9000
@@ -15,20 +26,19 @@ if [[ -z "$PHP_FPM_GROUP" ]]; then export PHP_FPM_GROUP=$XGROUP; fi
 if [[ -z "$PHP_FPM_LISTEN_OWNER" ]]; then export PHP_FPM_LISTEN_OWNER=$XLISTEN_OWNER; fi
 if [[ -z "$PHP_FPM_LISTEN_GROUP" ]]; then export PHP_FPM_LISTEN_GROUP=$XLISTEN_GROUP; fi
 
-CWD=/var/data/php-fpm
-
-envsubst < "$CWD/php-fpm.tmpl.conf" > "/usr/local/etc/php-fpm.conf"
 envsubst < "$CWD/www.tmpl.conf" > "/usr/local/etc/php-fpm.d/www.conf"
 
-
-# 2. PHP default settings (default-php.ini)
-# 2.1 [PHP]
+# 3. PHP default settings (default-php.ini)
+# 3.1 [PHP]
 XMEMORY_LIMIT=512M
-# 2.2 [Session]
+XEXPOSE_PHP=On
+# 3.2 [Session]
 XGC_MAXLIFETIME=1440
 
 if [[ -z "$PHP_MEMORY_LIMIT" ]];
     then export PHP_MEMORY_LIMIT=$XMEMORY_LIMIT; fi
+if [[ -z "$PHP_EXPOSE_PHP" ]];
+    then export PHP_EXPOSE_PHP=$XEXPOSE_PHP; fi
 if [[ -z "$PHP_SESSION_GC_MAXLIFETIME" ]];
     then export PHP_SESSION_GC_MAXLIFETIME=$XGC_MAXLIFETIME; fi
 

--- a/7.4-fpm/php-fpm.tmpl.conf
+++ b/7.4-fpm/php-fpm.tmpl.conf
@@ -21,7 +21,8 @@
 ; into a local file.
 ; Note: the default prefix is /usr/local/var
 ; Default Value: log/php-fpm.log
-error_log = /proc/self/fd/2
+; For Docker: /proc/self/fd/2
+error_log = $PHP_FPM_ERROR_LOG
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -39,7 +40,7 @@ error_log = /proc/self/fd/2
 ; Log level
 ; Possible Values: alert, error, warning, notice, debug
 ; Default Value: notice
-;log_level = notice
+log_level = $PHP_FPM_LOG_LEVEL
 
 ; Log limit on number of characters in the single line (log entry). If the
 ; line is over the limit, it is wrapped on multiple lines. The limit is for

--- a/7.4-fpm/php.tmpl.ini
+++ b/7.4-fpm/php.tmpl.ini
@@ -40,6 +40,15 @@ xdebug.profiler_enable  = Off
 xdebug.remote_enable    = Off
 xdebug.remote_autostart = Off
 
+;
+; Misc
+;
+; Decides whether PHP may expose the fact that it is installed on the server
+; (e.g. by adding its signature to the Web server header).  It is no security
+; threat in any way, but it makes it possible to determine whether you use PHP
+; on your server or not.
+; Default: On
+expose_php = $PHP_EXPOSE_PHP
 
 [Session]
 ; After this number of seconds, stored data will be seen as 'garbage' and

--- a/8.0-fpm/envsubst.sh
+++ b/8.0-fpm/envsubst.sh
@@ -2,7 +2,18 @@
 
 set -e
 
-# 1. PHP-FPM default settings (www.conf)
+CWD=/var/data/php-fpm
+
+# 1. PHP-FPM default settings (php-fpm.conf)
+XERROR_LOG=/proc/self/fd/2
+XLOG_LEVEL=error
+
+if [[ -z "$PHP_FPM_ERROR_LOG" ]]; then export PHP_FPM_ERROR_LOG=$XERROR_LOG; fi
+if [[ -z "$PHP_FPM_LOG_LEVEL" ]]; then export PHP_FPM_LOG_LEVEL=$XLOG_LEVEL; fi
+
+envsubst < "$CWD/php-fpm.tmpl.conf" > "/usr/local/etc/php-fpm.conf"
+
+# 2. PHP-FPM WWW Pool (www.conf)
 XUSER=www-data
 XGROUP=www-data
 XLISTEN=9000
@@ -15,20 +26,19 @@ if [[ -z "$PHP_FPM_GROUP" ]]; then export PHP_FPM_GROUP=$XGROUP; fi
 if [[ -z "$PHP_FPM_LISTEN_OWNER" ]]; then export PHP_FPM_LISTEN_OWNER=$XLISTEN_OWNER; fi
 if [[ -z "$PHP_FPM_LISTEN_GROUP" ]]; then export PHP_FPM_LISTEN_GROUP=$XLISTEN_GROUP; fi
 
-CWD=/var/data/php-fpm
-
-envsubst < "$CWD/php-fpm.tmpl.conf" > "/usr/local/etc/php-fpm.conf"
 envsubst < "$CWD/www.tmpl.conf" > "/usr/local/etc/php-fpm.d/www.conf"
 
-
-# 2. PHP default settings (default-php.ini)
-# 2.1 [PHP]
+# 3. PHP default settings (default-php.ini)
+# 3.1 [PHP]
 XMEMORY_LIMIT=512M
-# 2.2 [Session]
+XEXPOSE_PHP=On
+# 3.2 [Session]
 XGC_MAXLIFETIME=1440
 
 if [[ -z "$PHP_MEMORY_LIMIT" ]];
     then export PHP_MEMORY_LIMIT=$XMEMORY_LIMIT; fi
+if [[ -z "$PHP_EXPOSE_PHP" ]];
+    then export PHP_EXPOSE_PHP=$XEXPOSE_PHP; fi
 if [[ -z "$PHP_SESSION_GC_MAXLIFETIME" ]];
     then export PHP_SESSION_GC_MAXLIFETIME=$XGC_MAXLIFETIME; fi
 

--- a/8.0-fpm/php-fpm.tmpl.conf
+++ b/8.0-fpm/php-fpm.tmpl.conf
@@ -21,7 +21,8 @@
 ; into a local file.
 ; Note: the default prefix is /usr/local/var
 ; Default Value: log/php-fpm.log
-error_log = /proc/self/fd/2
+; For Docker: /proc/self/fd/2
+error_log = $PHP_FPM_ERROR_LOG
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -39,7 +40,7 @@ error_log = /proc/self/fd/2
 ; Log level
 ; Possible Values: alert, error, warning, notice, debug
 ; Default Value: notice
-;log_level = notice
+log_level = $PHP_FPM_LOG_LEVEL
 
 ; Log limit on number of characters in the single line (log entry). If the
 ; line is over the limit, it is wrapped on multiple lines. The limit is for

--- a/8.0-fpm/php.tmpl.ini
+++ b/8.0-fpm/php.tmpl.ini
@@ -40,6 +40,15 @@ xdebug.profiler_enable  = Off
 xdebug.remote_enable    = Off
 xdebug.remote_autostart = Off
 
+;
+; Misc
+;
+; Decides whether PHP may expose the fact that it is installed on the server
+; (e.g. by adding its signature to the Web server header).  It is no security
+; threat in any way, but it makes it possible to determine whether you use PHP
+; on your server or not.
+; Default: On
+expose_php = $PHP_EXPOSE_PHP
 
 [Session]
 ; After this number of seconds, stored data will be seen as 'garbage' and

--- a/README.md
+++ b/README.md
@@ -98,7 +98,16 @@ Below the environment variables with their default values:
 
 ### PHP-FPM
 
-Settings replaced into `www.conf` file.
+#### Global FPM
+
+Settings replaced into `/usr/local/etc/php-fpm.conf` file.
+
+- `PHP_FPM_ERROR_LOG=/proc/self/fd/2`
+- `PHP_FPM_LOG_LEVEL=error`
+
+#### FPM WWW Pool
+
+Settings replaced into `/usr/local/etc/php-fpm.d/www.conf` file.
 
 - `PHP_FPM_LISTEN=9000`
 - `PHP_FPM_USER=www-data`
@@ -108,9 +117,10 @@ Settings replaced into `www.conf` file.
 
 ### PHP Config
 
-Settings replaced into `php.ini` file.
+Settings replaced into `/usr/local/etc/php/conf.d/default-php.ini` file (`php.ini`).
 
 - `PHP_MEMORY_LIMIT=512M`
+- `PHP_EXPOSE_PHP=On`
 - `PHP_SESSION_GC_MAXLIFETIME=1440`
 
 ## Docker Compose Examples


### PR DESCRIPTION
This PR adds some new env variables for setup.

**PHP Config**

- `PHP_EXPOSE_PHP=On`

**Global FPM**

- `PHP_FPM_ERROR_LOG=/proc/self/fd/2`
- `PHP_FPM_LOG_LEVEL=error`
