### PR TITLE
Add `phalcon` extension for PHP 7.4, 8.0, 8.1

### DIFF
--- a/7.4-fpm/Dockerfile
+++ b/7.4-fpm/Dockerfile
@@ -203,6 +203,11 @@ RUN set -eux \
     && docker-php-ext-install -j$(nproc) pcntl \
     && true \
 \
+# Install phalcon
+    && pecl install phalcon \
+    && docker-php-ext-enable phalcon \
+    && true \
+\
 # Install pdo_pgsql
     && docker-php-ext-install -j$(nproc) pdo_pgsql \
     && true \

--- a/8.0-fpm/Dockerfile
+++ b/8.0-fpm/Dockerfile
@@ -205,6 +205,11 @@ RUN set -eux \
     && docker-php-ext-install -j$(nproc) pcntl \
     && true \
 \
+# Install phalcon
+    && pecl install phalcon \
+    && docker-php-ext-enable phalcon \
+    && true \
+\
 # Install pdo_pgsql
     && docker-php-ext-install -j$(nproc) pdo_pgsql \
     && true \

--- a/8.1-fpm/Dockerfile
+++ b/8.1-fpm/Dockerfile
@@ -197,6 +197,11 @@ RUN set -eux \
     && docker-php-ext-install -j$(nproc) pcntl \
     && true \
 \
+# Install phalcon
+    && pecl install phalcon \
+    && docker-php-ext-enable phalcon \
+    && true \
+\
 # Install pdo_pgsql
     && docker-php-ext-install -j$(nproc) pdo_pgsql \
     && true \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | pdo_pgsql  |   ✓    |      ✓ |      ✓ |
 | pdo_sqlsrv |   ✓    |      ✓ |      ✓ |
 | pgsql      |   ✓    |      ✓ |      ✓ |
+| phalcon    |   ✓    |      ✓ |      ✓ |
 | psr        |   ✓    |      ✓ |      ✓ |
 | redis      |   ✓    |      ✓ |      ✓ |
 | rdkafka    |   ✓    |      ✓ |      ✓ |


### PR DESCRIPTION
This PR adds [phalcon](https://github.com/phalcon/cphalcon) extension which resolves #16.