### PR TITLE
Zstd extension for PHP 8.0, 8.1, 8.2

### DIFF
--- a/8.0-fpm/Dockerfile
+++ b/8.0-fpm/Dockerfile
@@ -92,6 +92,7 @@ RUN set -eux \
         vips-dev \
         yaml-dev \
         zlib-dev \
+        zstd-dev \
 \
 # Workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
@@ -317,6 +318,11 @@ RUN set -eux \
 # Install zip
     && docker-php-ext-configure zip --with-zip \
     && docker-php-ext-install -j$(nproc) zip \
+    && true \
+\
+# Install zstd
+    && pecl install zstd \
+    && docker-php-ext-enable zstd \
     && true \
 \
 # Clean up build packages

--- a/8.1-fpm/Dockerfile
+++ b/8.1-fpm/Dockerfile
@@ -88,6 +88,7 @@ RUN set -eux \
         vips-dev \
         yaml-dev \
         zlib-dev \
+        zstd-dev \
 \
 # Workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
@@ -303,6 +304,11 @@ RUN set -eux \
 # Install zip
     && docker-php-ext-configure zip --with-zip \
     && docker-php-ext-install -j$(nproc) zip \
+    && true \
+\
+# Install zstd
+    && pecl install zstd \
+    && docker-php-ext-enable zstd \
     && true \
 \
 # Clean up build packages

--- a/8.2-fpm/Dockerfile
+++ b/8.2-fpm/Dockerfile
@@ -88,6 +88,7 @@ RUN set -eux \
         vips-dev \
         yaml-dev \
         zlib-dev \
+        zstd-dev \
 \
 # Workaround for rabbitmq linking issue
     && ln -s /usr/lib /usr/local/lib64 \
@@ -297,6 +298,11 @@ RUN set -eux \
 # Install zip
     && docker-php-ext-configure zip --with-zip \
     && docker-php-ext-install -j$(nproc) zip \
+    && true \
+\
+# Install zstd
+    && pecl install zstd \
+    && docker-php-ext-enable zstd \
     && true \
 \
 # Clean up build packages

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 | xsl        |      ✓ |      ✓ |      ✓ |
 | yaml       |      ✓ |      ✓ |      ✓ |
 | zip        |      ✓ |      ✓ |      ✓ |
+| zstd       |      ✓ |      ✓ |      ✓ |
 | &nbsp;     | &nbsp; | &nbsp; | &nbsp; |
 | **Others** |        |        |        |
 | composer   |   v2.5 |   v2.6 |   v2.6 |


### PR DESCRIPTION
This PR adds a new [Zstd](https://github.com/facebook/zstd) extension via https://github.com/kjdev/php-ext-zstd.