### PR TITLE
Update Linux ARM CI workflows to use the new ARM64 runner

### DIFF
--- a/.github/workflows/devel-8.1.yml
+++ b/.github/workflows/devel-8.1.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   php:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build:
@@ -27,14 +26,20 @@ jobs:
         include:
           - build: amd64
             arch: linux/amd64
+            os: ubuntu-22.04
           - build: "386"
             arch: linux/386
+            os: ubuntu-22.04
           - build: arm64
             arch: linux/arm64
+            os: ubuntu-22.04-arm
           - build: armv6
             arch: linux/arm/v6
+            os: ubuntu-22.04-arm
           - build: armv7
             arch: linux/arm/v7
+            os: ubuntu-22.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
       -
         name: Checkout
@@ -58,7 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build and Test
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: false
           provenance: false

--- a/.github/workflows/devel-8.2.yml
+++ b/.github/workflows/devel-8.2.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   php:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build:
@@ -27,14 +26,20 @@ jobs:
         include:
           - build: amd64
             arch: linux/amd64
+            os: ubuntu-22.04
           - build: "386"
             arch: linux/386
+            os: ubuntu-22.04
           - build: arm64
             arch: linux/arm64
+            os: ubuntu-22.04-arm
           - build: armv6
             arch: linux/arm/v6
+            os: ubuntu-22.04-arm
           - build: armv7
             arch: linux/arm/v7
+            os: ubuntu-22.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
       -
         name: Checkout
@@ -58,7 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build and Test
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: false
           provenance: false

--- a/.github/workflows/devel-8.3.yml
+++ b/.github/workflows/devel-8.3.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   php:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build:
@@ -27,14 +26,20 @@ jobs:
         include:
           - build: amd64
             arch: linux/amd64
+            os: ubuntu-22.04
           - build: "386"
             arch: linux/386
+            os: ubuntu-22.04
           - build: arm64
             arch: linux/arm64
+            os: ubuntu-22.04-arm
           - build: armv6
             arch: linux/arm/v6
+            os: ubuntu-22.04-arm
           - build: armv7
             arch: linux/arm/v7
+            os: ubuntu-22.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
       -
         name: Checkout
@@ -58,7 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build and Test
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: false
           provenance: false

--- a/.github/workflows/devel-8.4.yml
+++ b/.github/workflows/devel-8.4.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   php:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build:
@@ -27,14 +26,20 @@ jobs:
         include:
           - build: amd64
             arch: linux/amd64
-          - build: "386"
+            os: ubuntu-22.04
+          - build: 386
             arch: linux/386
+            os: ubuntu-22.04
           - build: arm64
             arch: linux/arm64
+            os: ubuntu-22.04-arm
           - build: armv6
             arch: linux/arm/v6
+            os: ubuntu-22.04-arm
           - build: armv7
             arch: linux/arm/v7
+            os: ubuntu-22.04-arm
+    runs-on: ${{ matrix.os }}
     steps:
       -
         name: Checkout
@@ -58,7 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build and Test
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: false
           provenance: false

--- a/.github/workflows/release-8.1.yml
+++ b/.github/workflows/release-8.1.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build:
@@ -19,14 +18,20 @@ jobs:
         include:
           - build: amd64
             arch: linux/amd64
+            os: ubuntu-22.04
           - build: 386
             arch: linux/386
+            os: ubuntu-22.04
           - build: arm64
             arch: linux/arm64
+            os: ubuntu-22.04-arm
           - build: armv6
             arch: linux/arm/v6
+            os: ubuntu-22.04-arm
           - build: armv7
             arch: linux/arm/v7
+            os: ubuntu-22.04-arm
+    runs-on: ${{ matrix.os }}
     name: PHP 8.1 (${{ matrix.build }})
     steps:
       -
@@ -56,7 +61,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           provenance: false

--- a/.github/workflows/release-8.2.yml
+++ b/.github/workflows/release-8.2.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build:
@@ -19,14 +18,20 @@ jobs:
         include:
           - build: amd64
             arch: linux/amd64
+            os: ubuntu-22.04
           - build: 386
             arch: linux/386
+            os: ubuntu-22.04
           - build: arm64
             arch: linux/arm64
+            os: ubuntu-22.04-arm
           - build: armv6
             arch: linux/arm/v6
+            os: ubuntu-22.04-arm
           - build: armv7
             arch: linux/arm/v7
+            os: ubuntu-22.04-arm
+    runs-on: ${{ matrix.os }}
     name: PHP 8.2 (${{ matrix.build }})
     steps:
       -
@@ -56,7 +61,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           provenance: false

--- a/.github/workflows/release-8.3.yml
+++ b/.github/workflows/release-8.3.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build:
@@ -19,14 +18,20 @@ jobs:
         include:
           - build: amd64
             arch: linux/amd64
+            os: ubuntu-22.04
           - build: 386
             arch: linux/386
+            os: ubuntu-22.04
           - build: arm64
             arch: linux/arm64
+            os: ubuntu-22.04-arm
           - build: armv6
             arch: linux/arm/v6
+            os: ubuntu-22.04-arm
           - build: armv7
             arch: linux/arm/v7
+            os: ubuntu-22.04-arm
+    runs-on: ${{ matrix.os }}
     name: PHP 8.3 (${{ matrix.build }})
     steps:
       -
@@ -56,7 +61,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           provenance: false

--- a/.github/workflows/release-8.4.yml
+++ b/.github/workflows/release-8.4.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build:
@@ -19,14 +18,20 @@ jobs:
         include:
           - build: amd64
             arch: linux/amd64
+            os: ubuntu-22.04
           - build: 386
             arch: linux/386
+            os: ubuntu-22.04
           - build: arm64
             arch: linux/arm64
+            os: ubuntu-22.04-arm
           - build: armv6
             arch: linux/arm/v6
+            os: ubuntu-22.04-arm
           - build: armv7
             arch: linux/arm/v7
+            os: ubuntu-22.04-arm
+    runs-on: ${{ matrix.os }}
     name: PHP 8.4 (${{ matrix.build }})
     steps:
       -
@@ -56,7 +61,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           provenance: false


### PR DESCRIPTION
This MR updates several ARM CI workflows to use the new Linux ARM64 hosted runners which increases build performance significantly.

Announcement: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/